### PR TITLE
feat: 包括的なテストスイートの実装とUserモデルバリデーション強化

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
+  validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :password, length: { minimum: 6 }, if: -> { new_record? || !password.nil? }
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,47 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# テストユーザーの作成
+puts "🌟 テストユーザーを作成中..."
+
+# 管理者ユーザー
+admin = User.find_or_create_by!(email_address: "admin@example.com") do |user|
+  user.password = "password123"
+  user.password_confirmation = "password123"
+end
+puts "👑 管理者ユーザーを作成しました: #{admin.email_address}"
+
+# 一般ユーザー
+test_users = [
+  {
+    email_address: "test@example.com",
+    password: "password123"
+  },
+  {
+    email_address: "astrology@example.com",
+    password: "password123"
+  },
+  {
+    email_address: "numerology@example.com",
+    password: "password123"
+  },
+  {
+    email_address: "user1@example.com",
+    password: "password123"
+  },
+  {
+    email_address: "user2@example.com",
+    password: "password123"
+  }
+]
+
+test_users.each do |user_data|
+  user = User.find_or_create_by!(email_address: user_data[:email_address]) do |user|
+    user.password = user_data[:password]
+    user.password_confirmation = user_data[:password]
+  end
+  puts "👤 ユーザーを作成しました: #{user.email_address}"
+end
+
+puts "✨ テストユーザーの作成が完了しました！"

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  # 認証が必要なダミーコントローラーを作成してテスト
+  class TestProtectedController < ApplicationController
+    def index
+      render plain: "Protected content"
+    end
+  end
+
+  class TestPublicController < ApplicationController
+    allow_unauthenticated_access
+
+    def index
+      render plain: "Public content"
+    end
+  end
+
+  test "should redirect to login when accessing protected content without authentication" do
+    with_routing do |set|
+      set.draw do
+        get "/protected", to: "application_controller_test/test_protected#index"
+        get "/sessions/new", to: "sessions#new", as: :new_session
+      end
+
+      get "/protected"
+      assert_redirected_to new_session_path
+    end
+  end
+
+  test "should allow access to public content without authentication" do
+    with_routing do |set|
+      set.draw do
+        get "/public", to: "application_controller_test/test_public#index"
+      end
+
+      get "/public"
+      assert_response :success
+      assert_equal "Public content", response.body
+    end
+  end
+
+  test "should allow access to protected content when authenticated" do
+    # ログイン
+    post session_url, params: {
+      email_address: @user.email_address,
+      password: "password"
+    }
+
+    with_routing do |set|
+      set.draw do
+        get "/protected", to: "application_controller_test/test_protected#index"
+      end
+
+      get "/protected"
+      assert_response :success
+      assert_equal "Protected content", response.body
+    end
+  end
+
+  test "should set return_to_after_authenticating when redirected" do
+    with_routing do |set|
+      set.draw do
+        get "/protected", to: "application_controller_test/test_protected#index"
+        get "/sessions/new", to: "sessions#new", as: :new_session
+      end
+
+      get "/protected"
+      assert_equal "/protected", session[:return_to_after_authenticating]
+    end
+  end
+
+  test "should clear return_to_after_authenticating after successful login" do
+    # 保護されたページにアクセス
+    with_routing do |set|
+      set.draw do
+        get "/protected", to: "application_controller_test/test_protected#index"
+        get "/sessions/new", to: "sessions#new", as: :new_session
+        post "/sessions", to: "sessions#create", as: :sessions
+        root to: "home#index"
+      end
+
+      get "/protected"
+      assert_equal "/protected", session[:return_to_after_authenticating]
+
+      # ログイン
+      post session_url, params: {
+        email_address: @user.email_address,
+        password: "password"
+      }
+
+      # return_to がクリアされることを確認
+      assert_nil session[:return_to_after_authenticating]
+    end
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class HomeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index without authentication" do
+    get root_url
+    assert_response :success
+    assert_select "title", /Fortune Telling App/
+  end
+
+  test "should display main heading" do
+    get root_url
+    assert_select "h1 span", /神秘の占い館/
+  end
+
+  test "should display fortune cards" do
+    get root_url
+    assert_select ".grid", 1
+    assert_select "h3", "タロット占い"
+    assert_select "h3", "星座占い"
+    assert_select "h3", "数秘術"
+  end
+
+  test "should display today's fortune section" do
+    get root_url
+    assert_select "h2", /今日のあなたの運勢/
+  end
+
+  test "should have mystical gradient background" do
+    get root_url
+    assert_select ".mystical-gradient"
+  end
+
+  test "should be accessible without login" do
+    # セッションをクリア
+    reset!
+
+    get root_url
+    assert_response :success
+    assert_no_match /new_session_path/, response.body
+  end
+
+  test "should have responsive design classes" do
+    get root_url
+    assert_select ".grid-cols-1"
+    assert_select ".md\\:grid-cols-3"
+  end
+
+  test "should display fortune card icons" do
+    get root_url
+    assert_select ".text-5xl", text: "🔮"
+    assert_select ".text-5xl", text: "⭐"
+    assert_select ".text-5xl", text: "🔢"
+  end
+end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get new" do
+    get new_password_url
+    assert_response :success
+    assert_select "form"
+    assert_select "input[name='email_address']"
+  end
+
+  test "should create password reset request with valid email" do
+    post passwords_url, params: {
+      email_address: @user.email_address
+    }
+    assert_redirected_to new_session_url
+    assert_match /password reset instructions/i, flash[:notice]
+  end
+
+  test "should not create password reset request with invalid email" do
+    post passwords_url, params: {
+      email_address: "invalid@example.com"
+    }
+    assert_response :unprocessable_entity
+    assert_select ".alert"
+  end
+
+  test "should not create password reset request with missing email" do
+    post passwords_url, params: {}
+    assert_response :unprocessable_entity
+  end
+
+  test "should get edit with valid token" do
+    # パスワードリセットトークンを生成（実際の実装に応じて調整）
+    token = "valid_token_example"
+    get edit_password_url(token: token)
+    assert_response :success
+    assert_select "form"
+    assert_select "input[name='password']"
+    assert_select "input[name='password_confirmation']"
+  end
+
+  test "should not get edit with invalid token" do
+    get edit_password_url(token: "invalid_token")
+    assert_redirected_to new_password_url
+    assert_match /invalid.*token/i, flash[:alert]
+  end
+
+  test "should not get edit without token" do
+    get edit_password_url(token: "")
+    assert_redirected_to new_password_url
+  end
+
+  test "should update password with valid token and password" do
+    # パスワードリセットトークンを生成（実際の実装に応じて調整）
+    token = "valid_token_example"
+
+    patch password_url(token: token), params: {
+      password: "newpassword123",
+      password_confirmation: "newpassword123"
+    }
+
+    assert_redirected_to new_session_url
+    assert_match /password.*updated/i, flash[:notice]
+  end
+
+  test "should not update password with mismatched confirmation" do
+    token = "valid_token_example"
+
+    patch password_url(token: token), params: {
+      password: "newpassword123",
+      password_confirmation: "differentpassword"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select ".alert"
+  end
+
+  test "should not update password with short password" do
+    token = "valid_token_example"
+
+    patch password_url(token: token), params: {
+      password: "short",
+      password_confirmation: "short"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select ".alert"
+  end
+
+  test "should not update password with invalid token" do
+    patch password_url(token: "invalid_token"), params: {
+      password: "newpassword123",
+      password_confirmation: "newpassword123"
+    }
+
+    assert_redirected_to new_password_url
+    assert_match /invalid.*token/i, flash[:alert]
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get new" do
+    get new_session_url
+    assert_response :success
+  end
+
+  test "should create session with valid credentials" do
+    post session_url, params: {
+      email_address: @user.email_address,
+      password: "password"
+    }
+    assert_redirected_to root_url
+  end
+
+    test "should not create session with invalid credentials" do
+    post session_url, params: {
+      email_address: "invalid@example.com",
+      password: "wrongpassword"
+    }
+    assert_redirected_to new_session_url
+  end
+
+  test "should destroy session" do
+    # ログイン
+    post session_url, params: {
+      email_address: @user.email_address,
+      password: "password"
+    }
+
+    # ログアウト
+    delete session_url
+    assert_redirected_to new_session_url
+  end
+
+  test "should create session record in database" do
+    assert_difference "Session.count", 1 do
+      post session_url, params: {
+        email_address: @user.email_address,
+        password: "password"
+      }
+    end
+  end
+end

--- a/test/fixtures/sessions.yml
+++ b/test/fixtures/sessions.yml
@@ -1,0 +1,9 @@
+one:
+  user: one
+  user_agent: "Mozilla/5.0 (Test Browser)"
+  ip_address: "127.0.0.1"
+
+two:
+  user: two
+  user_agent: "Chrome/Test"
+  ip_address: "192.168.1.100" 

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class CurrentTest < ActiveSupport::TestCase
+  test "should be a CurrentAttributes class" do
+    assert_kind_of ActiveSupport::CurrentAttributes, Current.new
+  end
+
+  test "should have session attribute" do
+    assert_respond_to Current, :session
+    assert_respond_to Current, :session=
+  end
+
+  test "should delegate user to session" do
+    user = users(:one)
+    session = sessions(:one)
+    session.user = user
+
+    Current.session = session
+    assert_equal user, Current.user
+  end
+
+  test "should return nil user when session is nil" do
+    Current.session = nil
+    assert_nil Current.user
+  end
+
+  test "should return nil user when session has no user" do
+    session = Session.new
+    Current.session = session
+    assert_nil Current.user
+  end
+
+  test "should allow setting and getting session" do
+    session = sessions(:one)
+    Current.session = session
+    assert_equal session, Current.session
+  end
+
+  test "should reset attributes" do
+    Current.session = sessions(:one)
+    assert_not_nil Current.session
+
+    Current.reset
+    assert_nil Current.session
+    assert_nil Current.user
+  end
+end

--- a/test/models/session_test.rb
+++ b/test/models/session_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class SessionTest < ActiveSupport::TestCase
+  test "should belong to user" do
+    session = Session.new
+    assert_respond_to session, :user
+  end
+
+  test "should be valid with user" do
+    session = Session.new(user: users(:one), user_agent: "Test Agent", ip_address: "127.0.0.1")
+    assert session.valid?
+  end
+
+  test "should require user" do
+    session = Session.new(user_agent: "Test Agent", ip_address: "127.0.0.1")
+    assert_not session.valid?
+    assert_includes session.errors[:user], "must exist"
+  end
+
+  test "should have user_agent and ip_address" do
+    session = sessions(:one) if defined?(sessions)
+    session ||= Session.create!(user: users(:one), user_agent: "Test Agent", ip_address: "127.0.0.1")
+
+    assert_respond_to session, :user_agent
+    assert_respond_to session, :ip_address
+  end
+
+  test "should be created with user association" do
+    user = users(:one)
+    session = user.sessions.create!(user_agent: "Test Browser", ip_address: "192.168.1.1")
+
+    assert_equal user, session.user
+    assert_includes user.sessions, session
+  end
+
+  test "should have timestamps" do
+    session = Session.create!(user: users(:one), user_agent: "Test Agent", ip_address: "127.0.0.1")
+
+    assert_not_nil session.created_at
+    assert_not_nil session.updated_at
+  end
+
+  test "should be destroyable" do
+    session = Session.create!(user: users(:one), user_agent: "Test Agent", ip_address: "127.0.0.1")
+    session_id = session.id
+
+    assert_difference "Session.count", -1 do
+      session.destroy
+    end
+
+    assert_nil Session.find_by(id: session_id)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,92 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should be valid with valid attributes" do
+    user = User.new(email_address: "test@example.com", password: "password123")
+    assert user.valid?
+  end
+
+  test "should require email_address" do
+    user = User.new(password: "password123")
+    assert_not user.valid?
+    assert_includes user.errors[:email_address], "can't be blank"
+  end
+
+  test "should require password" do
+    user = User.new(email_address: "test@example.com")
+    assert_not user.valid?
+  end
+
+  test "should normalize email_address to lowercase and strip whitespace" do
+    user = User.create!(email_address: "  TEST@EXAMPLE.COM  ", password: "password123")
+    assert_equal "test@example.com", user.email_address
+  end
+
+  test "should have unique email_address" do
+    User.create!(email_address: "test@example.com", password: "password123")
+    duplicate_user = User.new(email_address: "test@example.com", password: "password123")
+    assert_not duplicate_user.valid?
+    assert_includes duplicate_user.errors[:email_address], "has already been taken"
+  end
+
+  test "should authenticate with correct password" do
+    user = User.create!(email_address: "test@example.com", password: "password123")
+    assert user.authenticate("password123")
+    assert_not user.authenticate("wrongpassword")
+  end
+
+  test "should have secure password" do
+    user = User.new(email_address: "test@example.com", password: "password123")
+    assert_respond_to user, :authenticate
+    assert_respond_to user, :password_digest
+  end
+
+  test "should have many sessions" do
+    user = users(:one)
+    assert_respond_to user, :sessions
+    assert_equal "ActiveRecord::Associations::CollectionProxy", user.sessions.class.name
+  end
+
+      test "should destroy associated sessions when user is destroyed" do
+    user = users(:one)
+    # 新しいセッションを作成
+    session = user.sessions.create!(user_agent: "Test Agent", ip_address: "127.0.0.1")
+    session_id = session.id
+
+    # ユーザーを削除
+    user.destroy
+
+    # セッションも削除されていることを確認
+    assert_nil Session.find_by(id: session_id), "Session should be destroyed when user is destroyed"
+  end
+
+    test "should validate email format" do
+    valid_emails = %w[
+      user@example.com
+      test.email@example.co.jp
+      user+tag@example.org
+    ]
+
+    invalid_emails = %w[
+      invalid_email
+      @example.com
+      user@
+    ]
+
+    valid_emails.each do |email|
+      user = User.new(email_address: email, password: "password123")
+      assert user.valid?, "#{email} should be valid"
+    end
+
+    invalid_emails.each do |email|
+      user = User.new(email_address: email, password: "password123")
+      assert_not user.valid?, "#{email} should be invalid"
+    end
+  end
+
+  test "should require minimum password length" do
+    user = User.new(email_address: "test@example.com", password: "short")
+    assert_not user.valid?
+    assert_includes user.errors[:password], "is too short (minimum is 6 characters)"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,28 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+class ActionDispatch::IntegrationTest
+  # ログインヘルパー
+  def login_as(user)
+    post session_url, params: {
+      email_address: user.email_address,
+      password: "password"
+    }
+  end
+
+  # セッション作成ヘルパー
+  def create_session_for(user)
+    session = user.sessions.create!(
+      user_agent: "Test Agent",
+      ip_address: "127.0.0.1"
+    )
+    cookies.signed[:session_id] = session.id
+    session
+  end
+
+  # 認証状態の確認ヘルパー
+  def authenticated?
+    cookies.signed[:session_id].present?
+  end
+end


### PR DESCRIPTION
- Userモデルにバリデーション追加（email形式、一意性、パスワード最小長）
- 全モデルの単体テスト実装（User、Session、Current）
- 全コントローラーのテスト実装（Home、Sessions、Passwords、Application）
- テスト用seedデータ作成（管理者・一般ユーザー6名）
- テストヘルパー関数追加（ログイン、セッション作成、認証確認）
- fixtureファイル追加（sessions.yml）